### PR TITLE
Revert "Revert "Parfor for snippet computation ""

### DIFF
--- a/pop_roi_connect.m
+++ b/pop_roi_connect.m
@@ -41,7 +41,7 @@
 %  'fcomb'          - [struct] Frequency combination for which PAC is computed (in Hz). Must have fields 'low' and 
 %                     'high' with fcomb.low < fcomb.high. For example, fcomb.low = 10 and fcomb.high = 50 if single 
 %                     frequencies are used. fcomb.low = [4 8] and fcomb.high = [48 50] if frequency bands are used 
-%                     (might take a long time to compute so use with caution). Default is {} (this will cause an error).
+%                     (might take a long time to compute so use with caution). Default is {} (this will cause an error when PAC is selected).
 %  'bs_outopts'     - [integer] Option which bispectral tensors should be stored in EEG.roi.PAC. Default is 1.
 %                          1 - store all tensors: b_orig, b_anti, b_orig_norm, b_anti_norm
 %                          2 - only store: b_orig, b_anti
@@ -198,15 +198,14 @@ if length(EEG) > 1
 end
 
 % compute connectivity over snippets
-n_conn_metrics = length(g.methods); % number of connectivity metrics
-conn_matrices_snips = {};
-if strcmpi(g.snippet, 'on') && isempty(intersect(g.methods, {'PAC'})) && strcmpi(g.conn_stats, 'off')
+if strcmpi(g.snippet, 'on') && strcmpi(g.conn_stats, 'off')
+    % n_conn_metrics = length(g.methods); 
 
     snippet_length = g.snip_length; % seconds
     trials = size(EEG.roi.source_roi_data,3);
     pnts   = size(EEG.roi.source_roi_data,2);
-    snip_eps = snippet_length/(pnts/EEG.roi.srate); % n epochs in snippet
-    nsnips = floor(trials/snip_eps);
+    snip_eps = snippet_length/(pnts/EEG.roi.srate); % snip length/epoch length (how many trials for each snippet)
+    nsnips = floor(trials/snip_eps); 
     if nsnips < 1
         if strcmpi(g.errornosnippet, 'on')
             error('Snippet length cannot exceed data length.\n')
@@ -224,58 +223,129 @@ if strcmpi(g.snippet, 'on') && isempty(intersect(g.methods, {'PAC'})) && strcmpi
         nsnips = 1;
     end
     
+    % check if Parallel Processing Toolbox is available and licensed
+    if license('test', 'Distrib_Computing_Toolbox') && ~isempty(ver('parallel'))
+        if isfield(g, 'poolsize') && isnumeric(g.poolsize) && g.poolsize > 0
+            % check if there's already an existing parallel pool
+            currentPool = gcp('nocreate');
+            if isempty(currentPool)
+                parpool(g.poolsize);
+            end
+        end
+    else
+        disp('Parallel Processing Toolbox is not installed or licensed.');
+    end
+
+    tmplist1 = setdiff(g.methods, {'PAC'}); % list of fc metrics without PAC
+    tmplist2 = intersect(g.methods, {'PAC'});
+    % store each connectivity metric for each snippet in separate structure
+    fc_matrices_snips = cell(nsnips, length(tmplist1));
+    if ~isempty(tmplist2) 
+        switch g.bs_outopts % number of PAC metrics (check documentation)
+            case 1
+                bs_matrices_snips = cell(nsnips, 4); 
+                fns = cell(nsnips, 4);
+            otherwise
+                bs_matrices_snips = cell(nsnips, 2);
+                fns = cell(nsnips, 2);
+        end
+    end
     source_roi_data_save = EEG.roi.source_roi_data;
-    for isnip = 1:nsnips
+    parfor isnip = 1:nsnips
+%     for isnip = 1:nsnips
+        EEG1 = EEG;
         begSnip = (isnip-1)* snip_eps + 1;
         endSnip = min((isnip-1)* snip_eps + snip_eps, size(source_roi_data_save,3));
         roi_snip = source_roi_data_save(:,:, begSnip:endSnip ); % cut source data into snippets
-        EEG.roi.source_roi_data = single(roi_snip);
-        EEG = roi_connect(EEG, 'morder', g.morder, 'naccu', g.naccu, 'methods', g.methods,'freqresolution', g.freqresolution, 'roi_selection', g.roi_selection); % compute connectivity over one snippet
-        for fc = 1:n_conn_metrics 
-            fc_name = g.methods{fc};
-            fc_matrix = EEG.roi.(fc_name);
-            conn_matrices_snips{isnip,fc} = fc_matrix; % store each connectivity metric for each snippet in separate structure
+        EEG1.roi.source_roi_data = single(roi_snip);
+        EEG1 = roi_connect(EEG1, 'morder', g.morder, 'naccu', g.naccu, 'methods', g.methods,'freqresolution', g.freqresolution, 'roi_selection', g.roi_selection); % compute connectivity over one snippet
+        if ~isempty(intersect(g.methods, {'PAC'})) 
+            EEG1 = roi_pac(EEG1, g.fcomb, g.bs_outopts, g.roi_selection);
+        end
+        if ~isempty(tmplist1)
+            tmp_fc_matrices = cell(1, length(tmplist1));
+            for fc = 1:length(tmplist1) 
+                fc_name = g.methods{fc};
+                fc_matrix = EEG1.roi.(fc_name);
+                tmp_fc_matrices{fc} = fc_matrix;
+            end
+            fc_matrices_snips(isnip, :) = tmp_fc_matrices; 
+        end
+        if ~isempty(tmplist2)
+            tmp_fns = fieldnames(EEG1.roi.PAC);
+            tmp_bs_matrices = cell(1, length(tmp_fns));
+            for bs = 1:length(tmp_fns)
+                bs_matrix = EEG1.roi.PAC.(tmp_fns{bs});
+                tmp_bs_matrices{bs} = bs_matrix;
+            end
+            bs_matrices_snips(isnip, :) = tmp_bs_matrices; 
+            fns(isnip, :) = tmp_fns;
+        end
+    end
+
+    % shut down current parallel pool only if the toolbox is available
+    if license('test', 'Distrib_Computing_Toolbox') && ~isempty(ver('parallel'))
+        poolobj = gcp('nocreate');
+        if ~isempty(poolobj)
+            delete(poolobj);
         end
     end
     
     % compute mean over connectivity of each snippet
-    for fc = 1:n_conn_metrics
-        fc_name = g.methods{fc};
-        [first_dim, second_dim, third_dim] = size(conn_matrices_snips{1,fc});
-
-        conn_cell = conn_matrices_snips(:,fc); % store all matrices of one metric in a cell
-        mat = cell2mat(conn_cell);
-        reshaped = reshape(mat, first_dim, nsnips, second_dim, third_dim);
-        reshaped = squeeze(permute(reshaped, [2,1,3,4]));
-        if strcmpi(g.fcsave_format, 'all_snips')
-            EEG.roi.(fc_name) = reshaped;
-        else
-            if nsnips > 1
-                mean_conn = squeeze(mean(reshaped, 1));
+    if ~isempty(tmplist1)
+        for fc = 1:length(tmplist1)
+            fc_name = g.methods{fc};
+    
+            [first_dim, second_dim, third_dim] = size(fc_matrices_snips{1,fc});
+            conn_cell = fc_matrices_snips(:, fc); % store all matrices of one metric in a cell
+            mat = cell2mat(conn_cell);
+            reshaped = reshape(mat, first_dim, nsnips, second_dim, third_dim);
+            reshaped = squeeze(permute(reshaped, [2, 1, 3, 4]));
+            if strcmpi(g.fcsave_format, 'all_snips')
+                EEG.roi.(fc_name) = reshaped;
             else
-                mean_conn = reshaped;
+                if nsnips > 1
+                    mean_conn = squeeze(mean(reshaped, 1));
+                else
+                    mean_conn = reshaped;
+                end
+                EEG.roi.(fc_name) = mean_conn; % store mean connectivity in EEG struct
             end
-            EEG.roi.(fc_name) = mean_conn; % store mean connectivity in EEG struct
         end
     end
-
-elseif strcmpi(g.conn_stats, 'on')
-    % Pass fcomb
-    EEG = roi_connstats(EEG, 'methods', g.methods, 'nshuf', g.nshuf, 'roi_selection', g.roi_selection, 'freqresolution', g.freqresolution, 'poolsize', g.poolsize, 'fcomb', g.fcomb);
-    %EEG = roi_connstats(EEG, 'methods', g.methods, 'nshuf', g.nshuf, 'roi_selection', g.roi_selection, 'freqresolution', g.freqresolution, 'poolsize', g.poolsize);
-else
-    EEG = roi_connect(EEG, 'morder', g.morder, 'naccu', g.naccu, 'methods', g.methods,'freqresolution', g.freqresolution, ...
-        'roi_selection', g.roi_selection);
+    if ~isempty(tmplist2)
+        fns = fns(1, :);
+        for bs = 1:length(fns)
+            [second_dim, third_dim] = size(bs_matrices_snips{1, bs});
+            conn_cell = bs_matrices_snips(:, bs); % store all matrices of one metric in a cell
+            mat = cell2mat(conn_cell);
+            reshaped = reshape(mat, second_dim, nsnips, third_dim);
+            reshaped = squeeze(permute(reshaped, [2, 1, 3]));
+            if strcmpi(g.fcsave_format, 'all_snips')
+                EEG.roi.PAC.(fns{bs}) = reshaped;
+            else
+                if nsnips > 1
+                    mean_conn = squeeze(mean(reshaped, 1));
+                else
+                    mean_conn = reshaped;
+                end
+                EEG.roi.PAC.(fns{bs}) = mean_conn; % store mean connectivity in EEG struct
+            end
+        end
+    end
 end
 
-if ~isempty(intersect(g.methods, {'PAC'}))
-    if strcmpi(g.snippet, 'on')
-        error('Snippet analysis for PAC has not been implemented yet.')
-    else
+% TO-DO: add snippet option for stats mode
+if strcmpi(g.conn_stats, 'on')
+    EEG = roi_connstats(EEG, 'methods', g.methods, 'nshuf', g.nshuf, 'roi_selection', g.roi_selection, 'freqresolution', g.freqresolution, 'poolsize', g.poolsize, 'fcomb', g.fcomb);
+    %EEG = roi_connstats(EEG, 'methods', g.methods, 'nshuf', g.nshuf, 'roi_selection', g.roi_selection, 'freqresolution', g.freqresolution, 'poolsize', g.poolsize);
+end
+if strcmpi(g.snippet, 'off')
+    EEG = roi_connect(EEG, 'morder', g.morder, 'naccu', g.naccu, 'methods', g.methods,'freqresolution', g.freqresolution, 'roi_selection', g.roi_selection);
+    if strcmpi(g.snippet, 'off') && ~isempty(intersect(g.methods, {'PAC'}))
         EEG = roi_pac(EEG, g.fcomb, g.bs_outopts, g.roi_selection);
     end
 end
-
 if nargout > 1
     com = sprintf( 'EEG = pop_roi_connect(EEG, %s);', vararg2str( options ));
 end

--- a/test_pipes/pipeline_connectivity.m
+++ b/test_pipes/pipeline_connectivity.m
@@ -33,8 +33,8 @@ EEG = pop_leadfield(EEG, 'sourcemodel',fullfile(eeglabp,'plugins','dipfit','LORE
 % EEG = pop_leadfield(EEG, 'sourcemodel',fullfile(eeglabp,'functions','supportfiles','head_modelColin27_5003_Standard-10-5-Cap339.mat'), ...
 %     'sourcemodel2mni',[0 -24 -45 0 0 -1.5708 1000 1000 1000] ,'downsample',1);
 
-% EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3, 'chansel', EEG.dipfit.chansel);
-EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3);
+EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3, 'chansel', EEG.dipfit.chansel);
+% EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3);
 
 measures = { 'CS' 'COH' 'DTF'  'wPLI'  'PDC'  'MIM'  'MIC' 'GC' };
 % measures = { 'CS' 'COH' 'wPLI'  'PDC'  'MIM'  'MIC' 'GC' };

--- a/test_pipes/test_pac.m
+++ b/test_pipes/test_pac.m
@@ -20,7 +20,7 @@ EEG = pop_leadfield(EEG, 'sourcemodel',fullfile(eeglabp,'plugins','dipfit','LORE
     'sourcemodel2mni',[0 -24 -45 0 0 -1.5708 1000 1000 1000] ,'downsample',1);
 
 
-EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3);
+EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA', 3, 'chansel', EEG.dipfit.chansel);
 
 %% Test bispectrum for single frequency inputs
 low = 10;
@@ -31,7 +31,7 @@ fcomb.high = high;
 
 
 %EEG1 = pop_roi_connect(EEG, 'methods', {'PAC', 'MIM', 'COH'}, 'fcomb', fcomb); % test all 3 connectivity functions (data2spwctrgc, data2strgcmim, roi_pac)
-EEG2 = pop_roi_connect(EEG, 'methods', {'PAC'}, 'fcomb', fcomb, 'bs_outopts', 5, 'conn_stats', 'on', 'nshuf', 4); % compute only b_orig, b_orig_norm
+EEG2 = pop_roi_connect(EEG, 'methods', {'PAC'}, 'fcomb', fcomb, 'bs_outopts', 5, 'conn_stats', 'off', 'nshuf', 4); % compute only b_orig, b_orig_norm
 %EEG3 = pop_roi_connect(EEG, 'methods', {'PAC'}, 'fcomb', fcomb, 'bs_outopts', 5); % compute only b_anti, b_anti_norm
 
 %% Test bispectrum for frequency band inputs

--- a/test_pipes/test_snippets_connectivity.m
+++ b/test_pipes/test_snippets_connectivity.m
@@ -19,9 +19,15 @@ EEG = pop_dipfit_settings( EEG, 'hdmfile',fullfile(eeglabp, 'plugins','dipfit','
 EEG = pop_leadfield(EEG, 'sourcemodel',fullfile(eeglabp,'functions','supportfiles','head_modelColin27_5003_Standard-10-5-Cap339.mat'), ...
     'sourcemodel2mni',[0 -24 -45 0 0 -1.5708 1000 1000 1000] ,'downsample',1);
 
-EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3);
+EEG = pop_roi_activity(EEG, 'leadfield',EEG.dipfit.sourcemodel,'model','LCMV','modelparams',{0.05},'atlas','LORETA-Talairach-BAs','nPCA',3, 'chansel', EEG.dipfit.chansel);
 
-% snippet analysis, individual snippets are stored
-% EEG = pop_roi_connect(EEG, 'methods', { 'MIM' }, 'snippet', 'on', 'snip_length', 20, 'fcsave_format', 'all_snips');
+%% Snippet analysis, individual snippets are stored
+% EEG = pop_roi_connect(EEG, 'methods', { 'MIM' }, 'snippet', 'on', 'snip_length', 20); % 'fcsave_format', 'mean_snips'
 EEG = pop_roi_connect(EEG, 'morder',20,'naccu',[],'methods', {'CS', 'MIM'}, 'roi_selection', {}, 'snippet', 'on', 'snip_length', 20, 'fcsave_format', 'all_snips');
+
+% test for PAC
+fcomb.low = [8 10];
+fcomb.high = [20 22];
+EEG1 = pop_roi_connect(EEG, 'morder', 20,'naccu', [], 'methods', {'MIM', 'PAC'}, 'roi_selection', {}, 'fcomb', fcomb, 'snippet', 'on', 'snip_length', 20, 'fcsave_format', 'all_snips');
+EEG2 = pop_roi_connect(EEG, 'morder', 20,'naccu', [], 'methods', {'PAC'}, 'roi_selection', {}, 'fcomb', fcomb, 'snippet', 'on', 'snip_length', 20, 'fcsave_format', 'mean_snips');
 disp(size(EEG.roi.MIM)) % n_snips, frequency, roi, roi

--- a/utils/calc_pac.m
+++ b/utils/calc_pac.m
@@ -1,0 +1,25 @@
+function [biv_orig, biv_anti, biv_orig_norm, biv_anti_norm] = calc_pac(BS, RTP)
+    % calc_pac - Function to compute bicoherence and antisymmetrized bicoherence
+    % Inputs:
+    %  BS   - bispectrum frequency data
+    %  RTP  - Threenorm data
+    % 
+    % Outputs:
+    %  biv_orig      - Original bicoherence
+    %  biv_anti      - Antisymmetrized bicoherence
+    %  biv_orig_norm - Normalized original bicoherence
+    %  biv_anti_norm - Normalized antisymmetrized bicoherence
+
+    % Calculate bicoherence
+    biv_orig = squeeze(([mean(abs(BS(1, 2, 2, :))) mean(abs(BS(2, 1, 1, :)))])); % [Bkmm, Bmkk]
+    xx = BS - permute(BS, [2 1 3 4]);
+    biv_anti = squeeze(([abs(xx(1, 2, 2, :)) abs(xx(2, 1, 1, :))]));
+
+    % Calculate normalized bicoherence
+    bicoh = BS ./ RTP;
+    bicoh = mean(bicoh, 4); % average over frequency bands
+    biv_orig_norm = ([abs(bicoh(1, 2, 2)) abs(bicoh(2, 1, 1))]);
+    xx = bicoh - permute(bicoh, [2 1 3]);
+    biv_anti_norm = ([abs(xx(1, 2, 2)) abs(xx(2, 1, 1))]);
+
+end

--- a/utils/data2bs_pac.m
+++ b/utils/data2bs_pac.m
@@ -28,13 +28,13 @@ fs = params.fs;
 fres = fs;
 frqs = sfreqs(fres, fs);
 
-% extract all frequencies in the selected bands
+% extract all individual frequencies in the selected bands
 size_low = size(fcomb.low, 2);
 size_high = size(fcomb.high, 2);
-inds_low = frqs >= fcomb.low(1) & frqs <= fcomb.low(size_low);
-inds_high = frqs >= fcomb.high(1) & frqs <= fcomb.high(size_high);
-frqs_low = frqs(inds_low); 
-frqs_high = frqs(inds_high);
+mask_inds_low = frqs >= fcomb.low(1) & frqs <= fcomb.low(size_low);
+mask_inds_high = frqs >= fcomb.high(1) & frqs <= fcomb.high(size_high);
+frqs_low = frqs(mask_inds_low); 
+frqs_high = frqs(mask_inds_high);
 
 % determine all frequency combinations
 [m, n] = ndgrid(frqs_low, frqs_high);
@@ -58,11 +58,8 @@ end
 for proi = 1:nroi 
     for aroi = proi:nroi
         X = data([proi aroi],:,:); 
-        
         % upper freqs
-        [bs_up,~] = data2bs_event(X(:,:)', segleng, segshift, epleng, freqinds_up); 
-        % call function bs2pac(bs_up), this function does everything below and can hopefully then also be called in shuffle_BS (need to include nshuf info at some point)
-       
+        [bs_up,~] = data2bs_event(X(:,:)', segleng, segshift, epleng, freqinds_up);         
         biv_orig_up = squeeze(([mean(abs(bs_up(1, 2, 2, :))) mean(abs(bs_up(2, 1, 1, :)))])); % [Bkmm, Bmkk], average over frequency bands
         xx = bs_up - permute(bs_up, [2 1 3 4]); %Bkmm - Bmkm
         biv_anti_up = squeeze(([abs(xx(1, 2, 2, :)) abs(xx(2, 1, 1, :))]));
@@ -74,7 +71,14 @@ for proi = 1:nroi
         biv_orig_up_norm = ([abs(bicoh_up(1, 2, 2)) abs(bicoh_up(2, 1, 1))]);
         xx = bicoh_up-permute(bicoh_up, [2 1 3]);
         biv_anti_up_norm = ([abs(xx(1, 2, 2)) abs(xx(2, 1, 1))]);
-        
+
+%         % upper freqs
+%         [BS_up,~] = data2bs_event(X(:,:)', segleng, segshift, epleng, freqinds_up);
+%         % normalized by threenorm
+%         [RTP_up,~] = data2bs_threenorm(X(:,:)', segleng, segshift, epleng, freqinds_up);
+%         % calculate PAC
+%         [biv_orig_up, biv_anti_up, biv_orig_up_norm, biv_anti_up_norm] = calc_pac(BS_up, RTP_up);
+
         % lower freqs
         [bs_low,~] = data2bs_event(X(:,:)', segleng, segshift, epleng, freqinds_low);
         biv_orig_low = squeeze(([mean(abs(bs_low(1, 2, 2, :))) mean(abs(bs_low(2, 1, 1, :)))]));
@@ -88,7 +92,14 @@ for proi = 1:nroi
         biv_orig_low_norm = ([abs(bicoh_low(1, 2, 2)) abs(bicoh_low(2, 1, 1))]);
         xx = bicoh_low-permute(bicoh_low, [2 1 3]);
         biv_anti_low_norm = ([abs(xx(1, 2, 2)) abs(xx(2, 1, 1))]);
-        
+
+%         % lower freqs
+%         [BS_low,~] = data2bs_event(X(:,:)', segleng, segshift, epleng, freqinds_low);
+%         % normalized by threenorm
+%         [RTP_low,~] = data2bs_threenorm(X(:,:)', segleng, segshift, epleng, freqinds_low);
+%         % calculate PAC
+%         [biv_orig_low, biv_anti_low, biv_orig_low_norm, biv_anti_low_norm] = calc_pac(BS_low, RTP_low)
+
         % PAC_km(f1, f2) = 0.5 * |Bkmm(f1, f2-f1)| + 0.5 * |Bkmm(f1, f2)|
         b_orig(aroi,proi) = mean([biv_orig_up(1) biv_orig_low(1)]); 
         b_orig(proi,aroi) = mean([biv_orig_up(2) biv_orig_low(2)]);


### PR DESCRIPTION
Reverts sccn/roiconnect#72

Snippets can now be computed with **parfor**, making the computation faster than before, related to #43 and #44. It works for all FC metrics including PAC. 

Statistical testing for PAC is still ongoing (`shuffle_BS`, `data2bs_pac`, `calc_pac`). 

Edit: I accidentally merged the pull request already, but I reverted it for you to review. Now we need to revert the revert to merge the changes. Sorry for the confusion. You can check #71 to see what changed.